### PR TITLE
Remove deprecated gitsigns option

### DIFF
--- a/lua/config/plug/gitsigns.lua
+++ b/lua/config/plug/gitsigns.lua
@@ -42,5 +42,4 @@ require('gitsigns').setup({
 	update_debounce = 100,
 	status_formatter = nil, -- Use default
 	word_diff = false,
-	use_internal_diff = true, -- If luajit is present
 })


### PR DESCRIPTION
Not really nessecary, I believe it gives an error on startup as well 