### PR TITLE
[issue-21] fix: remove "lsp_diagnostics=false" from nvimtree.lua

### DIFF
--- a/lua/config/plug/nvimtree.lua
+++ b/lua/config/plug/nvimtree.lua
@@ -29,7 +29,6 @@ require('nvim-tree').setup({
 	open_on_tab = false,
 	hijack_cursor = false,
 	update_cwd = false,
-	lsp_diagnostics = false,
 
 	update_focused_file = {
 		enable = false,


### PR DESCRIPTION
Fixed error prompted in issue 21 with NvimTree lsp_diagnostics being deprecated.