### PR TITLE
update: treesitter and nvimtree config

### DIFF
--- a/lua/config/plug/nvimtree.lua
+++ b/lua/config/plug/nvimtree.lua
@@ -1,14 +1,11 @@
 local g = vim.g
 
 g.nvim_tree_auto_ignore_ft = { 'startify', 'dashboard' }
-g.nvim_tree_quit_on_open = 0
-g.nvim_tree_indent_markers = 1
 g.nvim_tree_git_hl = 1
 g.nvim_tree_highlight_opened_files = 1
 g.nvim_tree_root_folder_modifier = ':~'
 g.nvim_tree_add_trailing = 1
 g.nvim_tree_group_empty = 1
-g.nvim_tree_disable_window_picker = 0
 g.nvim_tree_icon_padding = ' '
 g.nvim_tree_symlink_arrow = ' >> '
 g.nvim_tree_show_icons = {
@@ -26,7 +23,7 @@ require'nvim-tree'.setup {
   open_on_tab         = false,
   hijack_cursor       = false,
   update_cwd          = false,
-  update_to_buf_dir   = {
+  hijack_directories = {
     enable = true,
     auto_open = true,
   },
@@ -62,7 +59,6 @@ require'nvim-tree'.setup {
     height = 30,
     hide_root_folder = false,
     side = 'left',
-    auto_resize = false,
     mappings = {
       custom_only = false,
       list = {}
@@ -74,5 +70,19 @@ require'nvim-tree'.setup {
   trash = {
     cmd = "trash",
     require_confirm = true
+  },
+  actions = {
+	  open_file = {
+		  quit_on_open = false,
+		  resize_window = false,
+		  window_picker = {
+			  enable = false 
+		  }
+	  }
+  },
+  renderer = {
+	  indent_markers = {
+		  enable = true
+	  }
   }
 }

--- a/lua/config/plug/treesitter.lua
+++ b/lua/config/plug/treesitter.lua
@@ -1,6 +1,6 @@
 require('nvim-treesitter.configs').setup({
-	-- One of "all", "maintained" (parsers with maintainers), or a list of languages
-	ensure_installed = 'maintained',
+	-- One of "all" or a list of languages
+	ensure_installed = {},
 
 	-- Install languages synchronously (only applied to `ensure_installed`)
 	sync_install = false,


### PR DESCRIPTION
Updated config for treesitter and nvimtree plugins
For treesitter:
`maintained` option was deprecated for `ensure_installed` ([source](https://github.com/nvim-treesitter/nvim-treesitter/issues/2293) and exact [comment](https://github.com/nvim-treesitter/nvim-treesitter/issues/2293#issuecomment-1113959051))

For nvimtree:
Some options were renamed, see [here](https://github.com/kyazdani42/nvim-tree.lua/issues/674#issue-1013281890)
Also `auto_close` option was deprecated (in same comment).